### PR TITLE
Related data belonging to another parent should not be updated

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,29 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-         cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false">
-    <coverage>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Feature">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
+  <testsuites>
+    <testsuite name="Feature">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="DB_CONNECTION" value="sqlite"/>
+    <env name="DB_DATABASE" value=":memory:"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,6 +30,13 @@ class ServiceProvider extends BaseServiceProvider
             // Get the current key values.
             $current = $this->newQuery()->pluck($relatedKeyName)->all();
 
+            // If the key value of the related entity does not belong to this parent, sets it to null to be considered as a new record
+            foreach ($data as $index => $relatedData) {
+                if (!in_array($relatedData[$relatedKeyName], $current, true)) {
+                    $data[$index][$relatedKeyName] = null;
+                }
+            }
+
             // Cast the given key to an integer if it is numeric.
             $castKey = function ($value) {
                 if (is_null($value)) {


### PR DESCRIPTION
When the primary key of the related data did not belong to parent, change was still being made.

Eg:
```
$user1->tasks()->sync([
            // Update
            [
                'id' => 3, // id from a task which belongs to another user
                'content' => 'Trying to change a task which is not mine',
            ],
 ]);
```

I see two approaches:
1) Ignore this record. In the example user1 would end with no tasks
2) Creates a new record. In the example user1 would end with a new task with another id
3) Throws an error

I implemented option 2 here.
